### PR TITLE
значение "пустая строка" валидно для селекта

### DIFF
--- a/src/components/select/select.jsx
+++ b/src/components/select/select.jsx
@@ -245,7 +245,7 @@ export default class Select extends React.Component {
                             )
                         })}
 
-                        {!multiple && value !== "" && (
+                        {!multiple && value !== undefined && !!options[value] && (
                             <span className={clsTag}>{options[value]}</span>
                         )}
                     </div>


### PR DESCRIPTION
штатная ситуация - значение пустая строка, описано как вариант выбора в селекте.
Без данной правки не будет отображаться как текущее.