### PR TITLE
пустая строка - валидній вариант значения.

### DIFF
--- a/src/components/select/select.jsx
+++ b/src/components/select/select.jsx
@@ -299,7 +299,7 @@ export default class Select extends React.Component {
                             <span className={'caption ' + clsTag} dangerouslySetInnerHTML={{__html: onDrawCaption(options[value])}}/>
                         )}
 
-                        {(!value || value === "" || value.length === 0) && (
+                        {(!value && !options[value] || value === undefined) && (
                             <span className={`placeholder ${clsPlaceholder}`}>{placeholder}</span>
                         )}
                     </div>


### PR DESCRIPTION
При валидном извне варианте вібора со значением пустой строки не нужен плейсхолдер.