### PR TITLE
Иначе переданое число 0 пишется перед текстом

### DIFF
--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -52,7 +52,7 @@ export default class Button extends React.Component{
                     <span className={'caption ' + clsTitle}>{title}</span>
                 )}
 
-                {badge && (
+                {badge !== null && (
                     <Badge value={badge} cls={clsBadge}/>
                 )}
 


### PR DESCRIPTION
Иначе переданое число 0 пишется перед текстом кнопки а не отображается в Badge